### PR TITLE
Enable CIFAR experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ OMP_NUM_THREADS=8 torchrun --nproc-per-node 8 pretrain.py data_path=data/maze-30
 
 *Runtime:* ~1 hour
 
+### CIFAR-10 Classification
+
+Prepare the dataset:
+
+```bash
+python dataset/build_cifar_dataset.py
+```
+
+Train with the classification architecture:
+
+```bash
+OMP_NUM_THREADS=8 python pretrain.py arch=hrm_v1_classifier data_path=data/cifar10 epochs=10 global_batch_size=512
+```
+
 ### Full Sudoku-Hard
 
 ```bash

--- a/config/arch/hrm_v1_classifier.yaml
+++ b/config/arch/hrm_v1_classifier.yaml
@@ -1,0 +1,22 @@
+name: hrm.hrm_act_v1_classifier@HierarchicalReasoningModel_ACTV1_Classifier
+loss:
+  name: losses@ACTClassificationLossHead
+
+halt_exploration_prob: 0.1
+halt_max_steps: 16
+
+H_cycles: 2
+L_cycles: 2
+
+H_layers: 4
+L_layers: 4
+
+hidden_size: 512
+num_heads: 8
+expansion: 4
+
+puzzle_emb_ndim: 0
+
+pos_encodings: rope
+
+num_classes: 10

--- a/dataset/build_cifar_dataset.py
+++ b/dataset/build_cifar_dataset.py
@@ -1,0 +1,84 @@
+import os
+import json
+import numpy as np
+from typing import Optional
+
+from argdantic import ArgParser
+from pydantic import BaseModel
+from tqdm import tqdm
+from torchvision.datasets import CIFAR10
+
+from common import PuzzleDatasetMetadata
+
+cli = ArgParser()
+
+
+class DataProcessConfig(BaseModel):
+    root: str = "data/cifar10_raw"
+    output_dir: str = "data/cifar10"
+    train: Optional[bool] = None
+
+
+def convert_subset(split: str, config: DataProcessConfig):
+    dataset = CIFAR10(root=config.root, train=(split == "train"), download=True)
+
+    inputs = []
+    labels = []
+    puzzle_indices = [0]
+    group_indices = [0]
+    puzzle_identifiers = []
+    example_id = 0
+    puzzle_id = 0
+
+    for img, label in tqdm(dataset):
+        arr = np.array(img, dtype=np.uint8)
+        inputs.append(arr.transpose(2, 0, 1).reshape(-1) + 1)  # shift by 1 for PAD=0
+        labels.append(np.array([label], dtype=np.int32))
+        example_id += 1
+        puzzle_id += 1
+        puzzle_indices.append(example_id)
+        puzzle_identifiers.append(0)
+        group_indices.append(puzzle_id)
+
+    results = {
+        "inputs": np.stack(inputs),
+        "labels": np.vstack(labels),
+        "group_indices": np.array(group_indices, dtype=np.int32),
+        "puzzle_indices": np.array(puzzle_indices, dtype=np.int32),
+        "puzzle_identifiers": np.array(puzzle_identifiers, dtype=np.int32),
+    }
+
+    metadata = PuzzleDatasetMetadata(
+        seq_len=32 * 32 * 3,
+        vocab_size=256 + 1,
+        pad_id=0,
+        ignore_label_id=None,
+        blank_identifier_id=0,
+        num_puzzle_identifiers=1,
+        total_groups=len(group_indices) - 1,
+        mean_puzzle_examples=1,
+        sets=["all"],
+    )
+
+    save_dir = os.path.join(config.output_dir, split)
+    os.makedirs(save_dir, exist_ok=True)
+
+    with open(os.path.join(save_dir, "dataset.json"), "w") as f:
+        json.dump(metadata.model_dump(), f)
+
+    for k, v in results.items():
+        np.save(os.path.join(save_dir, f"all__{k}.npy"), v)
+
+
+@cli.command(singleton=True)
+def preprocess_data(config: DataProcessConfig):
+    if config.train is None or config.train:
+        convert_subset("train", config)
+    if config.train is None or not config.train:
+        convert_subset("test", config)
+    with open(os.path.join(config.output_dir, "identifiers.json"), "w") as f:
+        json.dump(["<blank>"], f)
+
+
+if __name__ == "__main__":
+    cli()

--- a/models/hrm/hrm_act_v1_classifier.py
+++ b/models/hrm/hrm_act_v1_classifier.py
@@ -1,0 +1,38 @@
+import torch
+from torch import nn
+from typing import Dict, Tuple
+
+from models.layers import CastedLinear
+from models.hrm.hrm_act_v1 import (
+    HierarchicalReasoningModel_ACTV1,
+    HierarchicalReasoningModel_ACTV1Carry,
+)
+
+
+class HierarchicalReasoningModel_ACTV1_Classifier(nn.Module):
+    """HRM wrapper for image classification."""
+
+    def __init__(self, config_dict: dict, num_classes: int):
+        super().__init__()
+        self.hrm = HierarchicalReasoningModel_ACTV1(config_dict)
+        self.num_classes = num_classes
+        self.classifier = CastedLinear(
+            self.hrm.config.hidden_size, num_classes, bias=True
+        )
+
+    @property
+    def puzzle_emb(self):
+        return self.hrm.puzzle_emb
+
+    def initial_carry(self, batch: Dict[str, torch.Tensor]):
+        return self.hrm.initial_carry(batch)
+
+    def forward(
+        self,
+        carry: HierarchicalReasoningModel_ACTV1Carry,
+        batch: Dict[str, torch.Tensor],
+    ) -> Tuple[HierarchicalReasoningModel_ACTV1Carry, Dict[str, torch.Tensor]]:
+        carry, outputs = self.hrm(carry=carry, batch=batch)
+        hidden = carry.inner_carry.z_H[:, self.hrm.inner.puzzle_emb_len :, :]
+        outputs["cls_logits"] = self.classifier(hidden.mean(dim=1))
+        return carry, outputs

--- a/models/losses.py
+++ b/models/losses.py
@@ -9,16 +9,12 @@ IGNORE_LABEL_ID = -100
 
 
 def s(x, epsilon=1e-30):
-    return torch.where(
-        x<0,
-        1/(1-x+ epsilon),
-        x + 1
-    )
+    return torch.where(x < 0, 1 / (1 - x + epsilon), x + 1)
 
 
 def log_stablemax(x, dim=-1):
     s_x = s(x)
-    return torch.log(s_x/torch.sum(s_x, dim=dim, keepdim=True))
+    return torch.log(s_x / torch.sum(s_x, dim=dim, keepdim=True))
 
 
 def stablemax_cross_entropy(logits, labels, ignore_index: int = -100):
@@ -26,7 +22,9 @@ def stablemax_cross_entropy(logits, labels, ignore_index: int = -100):
 
     valid_mask = labels != ignore_index
     transformed_labels = torch.where(valid_mask, labels, 0)
-    prediction_logprobs = torch.gather(logprobs, index=transformed_labels.to(torch.long).unsqueeze(-1), dim=-1).squeeze(-1)
+    prediction_logprobs = torch.gather(
+        logprobs, index=transformed_labels.to(torch.long).unsqueeze(-1), dim=-1
+    ).squeeze(-1)
 
     return -torch.where(valid_mask, prediction_logprobs, 0)
 
@@ -34,7 +32,12 @@ def stablemax_cross_entropy(logits, labels, ignore_index: int = -100):
 def softmax_cross_entropy(logits, labels, ignore_index: int = -100):
     # Cast logits to f32
     # Flatten logits
-    return F.cross_entropy(logits.to(torch.float32).view(-1, logits.shape[-1]), labels.to(torch.long).view(-1), ignore_index=ignore_index, reduction="none").view(labels.shape)
+    return F.cross_entropy(
+        logits.to(torch.float32).view(-1, logits.shape[-1]),
+        labels.to(torch.long).view(-1),
+        ignore_index=ignore_index,
+        reduction="none",
+    ).view(labels.shape)
 
 
 class ACTLossHead(nn.Module):
@@ -42,7 +45,7 @@ class ACTLossHead(nn.Module):
         super().__init__()
         self.model = model
         self.loss_fn = globals()[loss_type]
-        
+
     def initial_carry(self, *args, **kwargs):
         return self.model.initial_carry(*args, **kwargs)  # type: ignore
 
@@ -51,7 +54,13 @@ class ACTLossHead(nn.Module):
         return_keys: Sequence[str],
         # Model args
         **model_kwargs,
-    ) -> Tuple[Any, torch.Tensor, Dict[str, torch.Tensor], Optional[Dict[str, torch.Tensor]], torch.Tensor]:
+    ) -> Tuple[
+        Any,
+        torch.Tensor,
+        Dict[str, torch.Tensor],
+        Optional[Dict[str, torch.Tensor]],
+        torch.Tensor,
+    ]:
         # Model logits
         # B x SeqLen x D
         new_carry, outputs = self.model(**model_kwargs)
@@ -61,41 +70,137 @@ class ACTLossHead(nn.Module):
         with torch.no_grad():
             mask = labels != IGNORE_LABEL_ID
             loss_counts = mask.sum(-1)
-            loss_divisor = loss_counts.clamp_min(1).unsqueeze(-1)  # Avoid NaNs in division
+            loss_divisor = loss_counts.clamp_min(1).unsqueeze(
+                -1
+            )  # Avoid NaNs in division
 
             is_correct = mask & (torch.argmax(outputs["logits"], dim=-1) == labels)
             seq_is_correct = is_correct.sum(-1) == loss_counts
-            
+
             # Metrics (halted)
             valid_metrics = new_carry.halted & (loss_counts > 0)
             metrics = {
                 "count": valid_metrics.sum(),
-                
-                "accuracy":       torch.where(valid_metrics, (is_correct.to(torch.float32) / loss_divisor).sum(-1), 0).sum(),
+                "accuracy": torch.where(
+                    valid_metrics,
+                    (is_correct.to(torch.float32) / loss_divisor).sum(-1),
+                    0,
+                ).sum(),
                 "exact_accuracy": (valid_metrics & seq_is_correct).sum(),
-
-                "q_halt_accuracy": (valid_metrics & ((outputs["q_halt_logits"] >= 0) == seq_is_correct)).sum(),
-                "steps":          torch.where(valid_metrics, new_carry.steps, 0).sum(),
+                "q_halt_accuracy": (
+                    valid_metrics & ((outputs["q_halt_logits"] >= 0) == seq_is_correct)
+                ).sum(),
+                "steps": torch.where(valid_metrics, new_carry.steps, 0).sum(),
             }
 
         # Losses
         # FIXME: Assuming the batch is always full
-        lm_loss = (self.loss_fn(outputs["logits"], labels, ignore_index=IGNORE_LABEL_ID) / loss_divisor).sum()
-        q_halt_loss = F.binary_cross_entropy_with_logits(outputs["q_halt_logits"], seq_is_correct.to(outputs["q_halt_logits"].dtype), reduction="sum")
+        lm_loss = (
+            self.loss_fn(outputs["logits"], labels, ignore_index=IGNORE_LABEL_ID)
+            / loss_divisor
+        ).sum()
+        q_halt_loss = F.binary_cross_entropy_with_logits(
+            outputs["q_halt_logits"],
+            seq_is_correct.to(outputs["q_halt_logits"].dtype),
+            reduction="sum",
+        )
 
-        metrics.update({
-            "lm_loss": lm_loss.detach(),
-            "q_halt_loss": q_halt_loss.detach(),
-        })
+        metrics.update(
+            {
+                "lm_loss": lm_loss.detach(),
+                "q_halt_loss": q_halt_loss.detach(),
+            }
+        )
 
         # Q continue (bootstrapping target loss)
         q_continue_loss = 0
         if "target_q_continue" in outputs:
-            q_continue_loss = F.binary_cross_entropy_with_logits(outputs["q_continue_logits"], outputs["target_q_continue"], reduction="sum")
+            q_continue_loss = F.binary_cross_entropy_with_logits(
+                outputs["q_continue_logits"],
+                outputs["target_q_continue"],
+                reduction="sum",
+            )
 
             metrics["q_continue_loss"] = q_continue_loss.detach()
 
         # Filter outputs for return
         detached_outputs = {k: outputs[k].detach() for k in return_keys if k in outputs}
 
-        return new_carry, lm_loss + 0.5 * (q_halt_loss + q_continue_loss), metrics, detached_outputs, new_carry.halted.all()
+        return (
+            new_carry,
+            lm_loss + 0.5 * (q_halt_loss + q_continue_loss),
+            metrics,
+            detached_outputs,
+            new_carry.halted.all(),
+        )
+
+
+class ACTClassificationLossHead(nn.Module):
+    """Loss head for classification tasks."""
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def initial_carry(self, *args, **kwargs):
+        return self.model.initial_carry(*args, **kwargs)
+
+    def forward(
+        self,
+        return_keys: Sequence[str],
+        **model_kwargs,
+    ) -> Tuple[
+        Any,
+        torch.Tensor,
+        Dict[str, torch.Tensor],
+        Optional[Dict[str, torch.Tensor]],
+        torch.Tensor,
+    ]:
+        new_carry, outputs = self.model(**model_kwargs)
+        labels = new_carry.current_data["labels"].view(-1)
+
+        with torch.no_grad():
+            preds = torch.argmax(outputs["cls_logits"], dim=-1)
+            valid_metrics = new_carry.halted
+            metrics = {
+                "count": valid_metrics.sum(),
+                "accuracy": torch.where(valid_metrics, (preds == labels), 0).sum(),
+                "exact_accuracy": torch.where(
+                    valid_metrics, (preds == labels), 0
+                ).sum(),
+                "q_halt_accuracy": (
+                    valid_metrics
+                    & ((outputs["q_halt_logits"] >= 0) == (preds == labels))
+                ).sum(),
+                "steps": torch.where(valid_metrics, new_carry.steps, 0).sum(),
+            }
+
+        ce_loss = F.cross_entropy(outputs["cls_logits"], labels, reduction="sum")
+        q_halt_loss = F.binary_cross_entropy_with_logits(
+            outputs["q_halt_logits"], (preds == labels).float(), reduction="sum"
+        )
+
+        metrics.update(
+            {
+                "ce_loss": ce_loss.detach(),
+                "q_halt_loss": q_halt_loss.detach(),
+            }
+        )
+
+        q_continue_loss = 0
+        if "target_q_continue" in outputs:
+            q_continue_loss = F.binary_cross_entropy_with_logits(
+                outputs["q_continue_logits"],
+                outputs["target_q_continue"],
+                reduction="sum",
+            )
+            metrics["q_continue_loss"] = q_continue_loss.detach()
+
+        detached_outputs = {k: outputs[k].detach() for k in return_keys if k in outputs}
+        return (
+            new_carry,
+            ce_loss + 0.5 * (q_halt_loss + q_continue_loss),
+            metrics,
+            detached_outputs,
+            new_carry.halted.all(),
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ wandb
 omegaconf
 hydra-core
 huggingface_hub
+torchvision


### PR DESCRIPTION
## Summary
- add CIFAR dataset builder
- create HRM classification wrapper and loss head
- add classifier arch config
- support torchvision dependency
- document CIFAR workflow

## Testing
- `python -m py_compile dataset/build_cifar_dataset.py models/hrm/hrm_act_v1_classifier.py models/losses.py`
- `python dataset/build_cifar_dataset.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6883e8b0eb5083268bf8c3ebfbd0cc02